### PR TITLE
fix: prevent previous line face's from extending into the symbol

### DIFF
--- a/trailing-newline-indicator.el
+++ b/trailing-newline-indicator.el
@@ -107,9 +107,9 @@ adds an indicator in the left margin for the visual empty line."
               (if (and trailing-newline-indicator-show-line-number
                        (bound-and-true-p display-line-numbers))
                   (let ((small-num
-                         (propertize (format "%d" (1+ line))
+                         (propertize (format " %d" (1+ line))
                                      'face 'trailing-newline-indicator-small-number)))
-                    (concat nl-symbol " " small-num))
+                    (concat nl-symbol small-num))
                 nl-symbol)))
         ;; Ensure margin is wide enough for line numbers
         (when win


### PR DESCRIPTION
If the previous face had something that could impact " ", such as a background, and, had :extend t, the " " portion of the symbol, only when we also display the line number, would take on the face of the previous line.