### PR TITLE
fix: remove invalid focus-in/out hook associations

### DIFF
--- a/trailing-newline-indicator.el
+++ b/trailing-newline-indicator.el
@@ -112,16 +112,11 @@ adds an indicator in the left margin for the visual empty line."
 ;;; Control Hooks Setup:
 (defun trailing-newline-indicator--hook-list ()
   "Return the list of hooks used by trailing-newline-indicator."
-  (append
-   ;; Use focus-in-hook if available and not obsolete, else use after-focus-change-function (Emacs 27.1+)
-   (if (boundp 'after-focus-change-function)
-       '(after-focus-change-function)
-     '(focus-in-hook))
-   '(after-change-functions
-     after-save-hook
-     after-revert-hook
-     kill-buffer-hook
-     post-command-hook)))
+  '(after-change-functions
+    after-save-hook
+    after-revert-hook
+    kill-buffer-hook
+    post-command-hook))
 
 (defun trailing-newline-indicator--setup-hooks ()
   "Setup necessary hooks for trailing newline indicator."


### PR DESCRIPTION
The `trailing-newline-indicator--update-indicator` function generated "Invalid function" errors when Emacs lost or gained focus due to external applications. This hook association has been removed entirely. The focus-related hooks (`focus-in-hook` and `after-focus-change-function`) are redundant, as the indicator is already correctly updated by other existing hooks, such as `after-change-functions` (for buffer edits) and `after-revert-hook` (for file reloading). The indicator does not strictly need to change just because a frame gains or loses focus.