### PR TITLE
docs: add MELPA badge at the top of the readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,3 +1,4 @@
+[[https://melpa.org/#/trailing-newline-indicator][file:https://melpa.org/packages/trailing-newline-indicator-badge.svg]]
 * trailing-newline-indicator
 
 Emacs does not show the file's trailing newline as a visible line, since it is


### PR DESCRIPTION
Like the title says: Add a MELPA badge at the top of the readme. Many Emacs packages have this to indicate that they are on MELPA, and also which version. (Version is rarely useful, but once in a while MELPA sync with sources fails, and the version is a bit older.).